### PR TITLE
Salva um valor padrão caso o usuário não tenha preenchido o bairro

### DIFF
--- a/includes/wc-class-itau-shopline-api.php
+++ b/includes/wc-class-itau-shopline-api.php
@@ -326,7 +326,7 @@ class WC_Itau_Shopline_API {
 			'registration'  => $document['code'],
 			'document'      => $document['number'],
 			'address'       => $order->billing_address_1,
-			'neighborhood'  => $order->billing_neighborhood,
+			'neighborhood'  => $order->billing_neighborhood != '' ? $order->billing_neighborhood : '-',
 			'zipcode'       => $this->only_numbers( $order->billing_postcode ),
 			'city'          => $order->billing_city,
 			'state'         => $order->billing_state,


### PR DESCRIPTION
A geração de boletos com o Shopline passou a dar "Erro de comunicação" continuamente.

Descobri que este erro na verdade ocorria quando o usuário não preenchia o seu bairro. Aparentemente em algum momento passou a ser obrigatório passar este parâmetro.

Nesta PR, se o usuário não preenche o bairro eu salvo o valor "-" só para ter algum dado para criptografar corretamente e enviar ao Shopline.