### PR TITLE
Implementado filtro para adiconar alguns dias ao cancelamento!

### DIFF
--- a/includes/wc-class-itau-shopline-api.php
+++ b/includes/wc-class-itau-shopline-api.php
@@ -443,7 +443,8 @@ class WC_Itau_Shopline_API {
 		$now   = strtotime( current_time( 'mysql' ) );
 
 		// Cancel order if expired.
-		if ( $order->wc_itau_shopline_expiry_time < $now && 'on-hold' === $order->get_status() ) {
+		$shopline_expiry_time = apply_filters('wc_itau_shopline_expiry_time', $order->wc_itau_shopline_expiry_time);
+		if ( $shopline_expiry_time < $now && 'on-hold' === $order->get_status() ) {
 			$order->update_status( 'cancelled', __( 'Itau Shopline: Order expired for lack of pay.', 'wc-itau-shopline' ) );
 
 			return false;


### PR DESCRIPTION
Costumo ter problemas com meus clientes pois não importa quantos dias se coloque para o vencimento muitos consumidores resolvem pagar no último dia e o banco irá retornar e D+1 (no mínimo) e quando isso ocorre normalmente o boleto já ficou com status de cancelado.
Além disso tem as questões como final de semana e feriados, então acho que mais simples colocar um filtro do que criar novos parâmetros ou fixar +5 dias para esperar o cancelamento. Desta forma cada um aplica os dias adicionais que quiser ou deixa o comportamento padrão de usar o dia do vencimento.